### PR TITLE
【FEAT】デモ用に8体分のデータを入力

### DIFF
--- a/MHWCrownApp/ContentView.swift
+++ b/MHWCrownApp/ContentView.swift
@@ -8,12 +8,17 @@
 import SwiftUI
 
 struct ContentView: View {
-    let monsterCrownData = MonsterCrownData()
+    @State var monsterCrownData = MonsterCrownData()
 
     var body: some View {
         NavigationView {
-            List(monsterCrownData.crownDataEntitys) { entity in
-                Text(entity.name ?? "モンスター名が未登録です")
+            List($monsterCrownData.crownDataEntitys) { $entity in
+                VStack(alignment: .leading) {
+                    Text(entity.name)
+                        .font(.headline)
+                    Toggle("金冠", isOn: $entity.isMaximum)
+                    Toggle("最小冠", isOn: $entity.isMinimum)
+                }
             }
             .navigationTitle("Monster Crown Data")
         }

--- a/MHWCrownApp/ContentView.swift
+++ b/MHWCrownApp/ContentView.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 
 struct ContentView: View {
+    let monsterCrownData = MonsterCrownData()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationView {
+            List(monsterCrownData.crownDataEntitys) { entity in
+                Text(entity.name ?? "モンスター名が未登録です")
+            }
+            .navigationTitle("Monster Crown Data")
         }
-        .padding()
         .onAppear {
             print(MonsterCrownData())
         }

--- a/MHWCrownApp/CrownDataEntity.swift
+++ b/MHWCrownApp/CrownDataEntity.swift
@@ -8,10 +8,19 @@
 import Foundation
 
 struct CrownDataEntity: Identifiable {
-    var id: Int?
-    var name: String?
-    var isLimitMaximum: Bool = false
-    var isMaximum: Bool = false
-    var isMinimum: Bool = false
-    var isLimitMinimum: Bool = false
+    var id: Int
+    var name: String
+    var isLimitMaximum: Bool
+    var isMaximum: Bool
+    var isMinimum: Bool
+    var isLimitMinimum: Bool
+
+    init(id: Int, name: String, isLimitMaximum: Bool, isMaximum: Bool, isMinimum: Bool, isLimitMinimum: Bool) {
+        self.id = id
+        self.name = name
+        self.isLimitMaximum = isLimitMaximum
+        self.isMaximum = isMaximum
+        self.isMinimum = isMinimum
+        self.isLimitMinimum = isLimitMinimum
+    }
 }

--- a/MHWCrownApp/CrownDataEntity.swift
+++ b/MHWCrownApp/CrownDataEntity.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CrownDataEntity {
+struct CrownDataEntity: Identifiable {
     var id: Int?
     var name: String?
     var isLimitMaximum: Bool = false

--- a/MHWCrownApp/CrownDataEntity.swift
+++ b/MHWCrownApp/CrownDataEntity.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct CrownDataEntity {
+    var id: Int?
+    var name: String?
     var isLimitMaximum: Bool = false
     var isMaximum: Bool = false
     var isMinimum: Bool = false

--- a/MHWCrownApp/MonsterCrownData.swift
+++ b/MHWCrownApp/MonsterCrownData.swift
@@ -13,35 +13,67 @@ public struct MonsterCrownData {
     init() {
         let firstEntity = CrownDataEntity(
             id: 1,
-            name: "ラージャン"
+            name: "ラージャン",
+            isLimitMaximum: false,
+            isMaximum: false,
+            isMinimum: false,
+            isLimitMinimum: false
         )
         let secondEntity = CrownDataEntity(
             id: 2,
-            name: "激昂ラージャン"
+            name: "激昂ラージャン",
+            isLimitMaximum: false,
+            isMaximum: false,
+            isMinimum: false,
+            isLimitMinimum: false
         )
         let thirdEntity = CrownDataEntity(
             id: 3,
-            name: "リオレウス"
+            name: "リオレウス",
+            isLimitMaximum: false,
+            isMaximum: false,
+            isMinimum: false,
+            isLimitMinimum: false
         )
         let fourEntity = CrownDataEntity(
             id: 4,
-            name: "リオレウス亜種"
+            name: "リオレウス亜種",
+            isLimitMaximum: false,
+            isMaximum: false,
+            isMinimum: false,
+            isLimitMinimum: false
         )
         let fifthEntity = CrownDataEntity(
             id: 5,
-            name: "リオレウス希少種"
+            name: "リオレウス希少種",
+            isLimitMaximum: false,
+            isMaximum: false,
+            isMinimum: false,
+            isLimitMinimum: false
         )
         let sixthEntity = CrownDataEntity(
             id: 6,
-            name: "リオレイア"
+            name: "リオレイア",
+            isLimitMaximum: false,
+            isMaximum: false,
+            isMinimum: false,
+            isLimitMinimum: false
         )
         let seventhEntity = CrownDataEntity(
             id: 7,
-            name: "リオレイア亜種"
+            name: "リオレイア亜種",
+            isLimitMaximum: false,
+            isMaximum: false,
+            isMinimum: false,
+            isLimitMinimum: false
         )
         let eighthEntity = CrownDataEntity(
             id: 8,
-            name: "リオレイア希少種"
+            name: "リオレイア希少種",
+            isLimitMaximum: false,
+            isMaximum: false,
+            isMinimum: false,
+            isLimitMinimum: false
         )
         self.crownDataEntitys = [firstEntity, secondEntity, thirdEntity, fourEntity, fifthEntity, sixthEntity, seventhEntity, eighthEntity]
     }

--- a/MHWCrownApp/MonsterCrownData.swift
+++ b/MHWCrownApp/MonsterCrownData.swift
@@ -11,8 +11,38 @@ public struct MonsterCrownData {
     var crownDataEntitys: [CrownDataEntity]
 
     init() {
-        let firstEntity = CrownDataEntity(isLimitMaximum: true, isMaximum: true, isMinimum: true, isLimitMinimum: true)
-        let secondEntity = CrownDataEntity(isMinimum: true, isLimitMinimum: true)
-        self.crownDataEntitys = [firstEntity, secondEntity]
+        let firstEntity = CrownDataEntity(
+            id: 1,
+            name: "ラージャン"
+        )
+        let secondEntity = CrownDataEntity(
+            id: 2,
+            name: "激昂ラージャン"
+        )
+        let thirdEntity = CrownDataEntity(
+            id: 3,
+            name: "リオレウス"
+        )
+        let fourEntity = CrownDataEntity(
+            id: 4,
+            name: "リオレウス亜種"
+        )
+        let fifthEntity = CrownDataEntity(
+            id: 5,
+            name: "リオレウス希少種"
+        )
+        let sixthEntity = CrownDataEntity(
+            id: 6,
+            name: "リオレイア"
+        )
+        let seventhEntity = CrownDataEntity(
+            id: 7,
+            name: "リオレイア亜種"
+        )
+        let eighthEntity = CrownDataEntity(
+            id: 8,
+            name: "リオレイア希少種"
+        )
+        self.crownDataEntitys = [firstEntity, secondEntity, thirdEntity, fourEntity, fifthEntity, sixthEntity, seventhEntity, eighthEntity]
     }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
## 概要 (Abstract)
デモ用に8体分のデータを入力
トグルの追加

<!-- If this pull request resolves any GitHub issues -->
## 関連するISSUE
- resolve #6

## 詳細 (Detail)
<!-- Thank you for your contribution! -->

<!-- スクリーンショットテンプレート
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="320" alt="ファイル名" src="URL"></td>
    <td><img width="320" alt="ファイル名" src="URL"></td>
  </tr>
</table>
-->